### PR TITLE
Allow selecting a display based on its position on the overal desktop layout

### DIFF
--- a/window_manager/README.md
+++ b/window_manager/README.md
@@ -8,18 +8,22 @@ This page describes options that are available on the options page (`chrome-exte
 
 Action defines how the window should be moved and resized. Following fields are supported:
 
-- `id` - **required**, identifier of the action, used in matchers to reference the action 
+- `id` - **required**, identifier of the action, used in matchers to reference the action
 
 - `display` - **required**, name of display, the action will not be performed if the display of given name doesn't exist.
-  
+
   Available values:
   - `primary` - display defined as primary
   - `-primary` - display that is not primary (if there are multiple non primary displays the first one will be used)
   - `internal` - display defined as internal
   - `-internal` - display that is not internal (if there are multiple non internal displays the first one will be used)
   - `[name of the display]` - name of the display, e.g. `DELL U4021QW`.
-  
+
   _Hint: List of displays is printed at the top of the extension options page._
+
+- `displayPosition` - the position of the display in the overall desktop with `top` and/or `left` fields. Allows selecting a display from multiple monitors with the same name based on the desktop layout.
+
+  _Hint: The positions of the displays is printed at the top of the extension options page._
 
 - `shortcutId` - action will be triggered by the shortcut of given id as defined on the shortcuts page (`chrome://extensions/shortcuts`).
 
@@ -30,7 +34,7 @@ Action defines how the window should be moved and resized. Following fields are 
 - `row `- definition of row
 
 - `menuName` - if set, the action will be shown in the popup menu of extension
-  
+
   _Hint: you can use unicode characters in the menu name._
 
 The `row` and `column` objects are defined using `start` and `end` fields. Following values of `start` and `end` are allowed:
@@ -85,7 +89,7 @@ Matchers define which action should be applied on a matched window. Following fi
 - `anyTabUrl` - url as string. The window will be matched if any of its tabs urls matches this string.
 
   _**Default**: any url_
-  
+
 - `minTabsNum` - number of tabs. Window will be matched when it has at least `minTabsNum` tabs opened.
 
   _**Default**: 0_
@@ -130,6 +134,34 @@ Since the extension requires JSON knowledge to define the actions and matchers, 
 
 ## FAQ
 
+### How to select multiple displays with the same name?
+
+One option is to specify one as primary, and the other as not primary, but if
+this is not possible, or you have more than 2 displays, use the
+`displayPosition` parameter of the action to specify the position of the
+required display in the overall desktop.
+
+eg:
+
+```json
+[
+  {
+    "id": "external-left @ half-left",
+    "display": "DISPLAYNAME",
+    "displayPosition": {"left": 0},
+    "column": {"start": 0, "end": "50%"},
+    "row": {"start": 0, "end": "100%"}
+  },
+  {
+    "id": "external-right @ half-left",
+    "display": "DISPLAYNAME",
+    "displayPosition": {"left": 2560},
+    "column": {"start": 0, "end": "50%"},
+    "row": {"start": 0, "end": "100%"}
+  }
+]
+```
+
 ### How to use multiple displays with priority?
 Actions are performed in an order of matchers. Let's assume you want to process `github.com` window:
 - on the external display the window should occupy left half of the screen
@@ -172,7 +204,7 @@ Matchers are processed in order of definition. If both internal and non internal
 
 <details>
   <summary>Actions</summary>
-  
+
 ```json
 [
   {
@@ -523,16 +555,6 @@ Matchers are processed in order of definition. If both internal and non internal
       "calculator"
     ],
     "anyTabUrl": "//birnenlabs.com/pwa/calculator/index.html",
-    "windowTypes": [
-      "app"
-    ]
-  },
-  {
-    "actions": [
-      "internal-column2",
-      "ide"
-    ],
-    "anyTabUrl": "//cider-v.corp.google.com",
     "windowTypes": [
       "app"
     ]

--- a/window_manager/options.html
+++ b/window_manager/options.html
@@ -16,37 +16,41 @@
       pre {
         font-size: 9pt;
       }
-      
+
       textarea {
         width: 100%;
+      }
+
+      #displays {
+        font-family: monospace;
       }
     </style>
   </head>
   <body>
     <div id="content">
       <h1>Displays</h1>
-      
+
       <ul id="displays"></ul>
 
       <h1>Options</h1>
 
       Please follow the
       <a href='https://github.com/birnenlabs/chrome-extensions/blob/main/window_manager/README.md'>documentation on github</a>.
-      
+
       <h2>Actions</h2>
-      
+
       <div class="status" id="actionsInputStatus"></div>
       <textarea id="actionsInput" rows="25" cols="50"></textarea>
-      
+
       <h2>Matchers</h2>
-      
+
       <div class="status" id="matchersInputStatus"></div>
       <textarea id="matchersInput" rows="25" cols="50"></textarea>
 
       <h2>Settings</h2>
       <div class="status" id="settingsInputStatus"></div>
       <textarea id="settingsInput" rows="10" cols="50"></textarea>
-  
+
       <div class="status" id="status"></div>
       <button id="validate">Validate</button>
       <button id="format">Format</button>

--- a/window_manager/options.js
+++ b/window_manager/options.js
@@ -83,7 +83,9 @@ async function showDisplays() {
   el.textContent = '';
   for (const display of displays) {
     const displayEl = document.createElement('li');
-    displayEl.textContent = `name: '${display.name}', primary: '${display.isPrimary}', internal: '${display.isInternal}'`;
+    delete display.bounds.width;
+    delete display.bounds.height;
+    displayEl.textContent = `name: '${display.name}', primary: '${display.isPrimary}', internal: '${display.isInternal}', position: '${JSON.stringify(display.bounds)}'`
     el.appendChild(displayEl);
   }
 }

--- a/window_manager/options.js
+++ b/window_manager/options.js
@@ -21,8 +21,10 @@ function validateOptions() {
   const settings = document.getElementById('settingsInput').value;
 
   let valid = true;
+  let actionsObj;
+  let matchersObj;
   try {
-    JSON.parse(actions);
+    actionsObj = JSON.parse(actions);
     document.getElementById('actionsInputStatus').textContent = '';
   } catch (e) {
     document.getElementById('actionsInputStatus').textContent = e.message;
@@ -30,7 +32,7 @@ function validateOptions() {
   }
 
   try {
-    JSON.parse(matchers);
+    matchersObj=JSON.parse(matchers);
     document.getElementById('matchersInputStatus').textContent = '';
   } catch (e) {
     document.getElementById('matchersInputStatus').textContent = e.message;
@@ -46,9 +48,20 @@ function validateOptions() {
   }
 
   if (valid) {
-    setStatus('Valid');
+    // verify matchers reference valid actions.
+    const actionIDs = new Set(actionsObj.map((a) => a.id));
+    const referencedActionIDs = new Set(matchersObj.map((m)=> m.actions).flat());
+
+    const missing = [...referencedActionIDs.values()].filter((id) => !actionIDs.has(id));
+    if(missing.length > 0) {
+      document.getElementById('matchersInputStatus').textContent = `matchers refer to unknown action ids: ${JSON.stringify(missing)}`;
+      valid =  false;
+    }
   }
 
+  if(valid) {
+    setStatus('Valid');
+  }
   return valid;
 }
 


### PR DESCRIPTION
Add a `displayPosition` to Actions, and compare against display bounds for selecting the display... 

eg: 
```json
  {
    "id": "HP Z27n left @ right half",
    "display": "HP Z27n",
    "displayPosition": { "left": 0 },
    "column": { "start": "50%", "end": "100%" },
    "row": { "start": 0, "end": "100%" }
  },
  {
    "id": "HP Z27n right @ top left",
    "display": "HP Z27n",
    "displayPosition": { "left": 2560 },
    "column": {  "start": "0%", "end": "50%"  },
    "row": {  "start": 0, "end": "66%"  }
  },
  {
    "id": "HP Z27n right @ top right",
    "display": "HP Z27n",
    "displayPosition": { "left": 2560 },
    "column": {  "start": "50%", "end": "100%"  },
    "row": {  "start": 0, "end": "66%"  }
  }
```