### PR TITLE
Add handling for display ID, improve Options page, matching and validation

### DIFF
--- a/window_manager/README.md
+++ b/window_manager/README.md
@@ -8,18 +8,19 @@ This page describes options that are available on the options page (`chrome-exte
 
 Action defines how the window should be moved and resized. Following fields are supported:
 
-- `id` - **required**, identifier of the action, used in matchers to reference the action 
+- `id` - **required**, identifier of the action, used in matchers to reference the action
 
 - `display` - **required**, name of display, the action will not be performed if the display of given name doesn't exist.
-  
+
   Available values:
   - `primary` - display defined as primary
   - `-primary` - display that is not primary (if there are multiple non primary displays the first one will be used)
   - `internal` - display defined as internal
   - `-internal` - display that is not internal (if there are multiple non internal displays the first one will be used)
   - `[name of the display]` - name of the display, e.g. `DELL U4021QW`.
-  
-  _Hint: List of displays is printed at the top of the extension options page._
+  - `[id of the display]` - ChromeOS internal display ID (useful when you have multiple displays with the same name);
+
+  _Hint: A List of displays with their names and IDs is printed at the top of the extension options page._
 
 - `shortcutId` - action will be triggered by the shortcut of given id as defined on the shortcuts page (`chrome://extensions/shortcuts`).
 
@@ -32,7 +33,7 @@ Action defines how the window should be moved and resized. Following fields are 
 - `row `- definition of row
 
 - `menuName` - if set, the action will be shown in the popup menu of extension
-  
+
   _Hint: you can use unicode characters in the menu name._
 
 The `row` and `column` objects are defined using `start` and `end` fields. Following values of `start` and `end` are allowed:
@@ -87,7 +88,7 @@ Matchers define which action should be applied on a matched window. Following fi
 - `anyTabUrl` - url as string. The window will be matched if any of its tabs urls matches this string.
 
   _**Default**: any url_
-  
+
 - `minTabsNum` - number of tabs. Window will be matched when it has at least `minTabsNum` tabs opened.
 
   _**Default**: 0_
@@ -174,7 +175,7 @@ Matchers are processed in order of definition. If both internal and non internal
 
 <details>
   <summary>Actions</summary>
-  
+
 ```json
 [
   {
@@ -525,16 +526,6 @@ Matchers are processed in order of definition. If both internal and non internal
       "calculator"
     ],
     "anyTabUrl": "//birnenlabs.com/pwa/calculator/index.html",
-    "windowTypes": [
-      "app"
-    ]
-  },
-  {
-    "actions": [
-      "internal-column2",
-      "ide"
-    ],
-    "anyTabUrl": "//cider-v.corp.google.com",
     "windowTypes": [
       "app"
     ]

--- a/window_manager/README.md
+++ b/window_manager/README.md
@@ -18,7 +18,7 @@ Action defines how the window should be moved and resized. Following fields are 
   - `internal` - display defined as internal
   - `-internal` - display that is not internal (if there are multiple non internal displays the first one will be used)
   - `[name of the display]` - name of the display, e.g. `DELL U4021QW`.
-  - `[id of the display]` - ChromeOS internal display ID (useful when you have multiple displays with the same name);
+  - `[id of the display]` - ChromeOS internal display ID (useful when you have multiple displays with the same name)
 
   _Hint: A List of displays with their names and IDs is printed at the top of the extension options page._
 

--- a/window_manager/classes/action.js
+++ b/window_manager/classes/action.js
@@ -48,12 +48,10 @@ export class Action {
         return displays.find(display => display.isInternal === false);
       default:
         // Match by display Name or display ID
-        displays = displays.filter((d) => {
-          return this.display == d.id // this.display is a string, d.id is a number
-              || this.display === d.name
-        });
-        // return first match.
-        return displays.length > 0 ? displays[0] : null;
+        return displays.find(display => (
+            display.name === this.display
+            || display.id == this.display // note this is a number == string comparison
+          ));
     }
   }
 

--- a/window_manager/classes/action.js
+++ b/window_manager/classes/action.js
@@ -11,13 +11,13 @@ export class Action {
   shortcutId;
 
   static loadAll() {
-    return chrome.storage.sync.get({actions: ''})
+    return chrome.storage.sync.get({actions: '[]'})
       .then(items => items.actions)
-      .then(actions => (actions 
+      .then(actions => (actions
                         ? JSON.parse(actions).map(a => Action.from(a))
                         : []));
   }
-  
+
   static from(json) {
     if (!json.id) {
       console.error(json);
@@ -47,17 +47,23 @@ export class Action {
       case '-internal':
         return displays.find(display => display.isInternal === false);
       default:
-        return displays.find(display => display.name === this.display);
+        // Match by display Name or display ID
+        displays = displays.filter((d) => {
+          return this.display == d.id // this.display is a string, d.id is a number
+              || this.display === d.name
+        });
+        // return first match.
+        return displays.length > 0 ? displays[0] : null;
     }
   }
-  
+
   createUpdate(displays) {
     const display = this.findDisplay(displays);
     if (!display) {
       console.debug(`Display ${this.display} not found`);
-      return {};
+      return null;
     }
-    
+
     const windowsUpdate = {
       state: 'normal',
       focused: true

--- a/window_manager/classes/matcher.js
+++ b/window_manager/classes/matcher.js
@@ -7,9 +7,9 @@ export class Matcher {
   actions;
 
   static loadAll() {
-    return chrome.storage.sync.get({matchers: '' })
+    return chrome.storage.sync.get({matchers: '[]' })
       .then(items => items.matchers)
-      .then(matchers => (matchers 
+      .then(matchers => (matchers
                         ? JSON.parse(matchers).map(a => Matcher.from(a))
                         : []));
   }

--- a/window_manager/classes/settings.js
+++ b/window_manager/classes/settings.js
@@ -7,7 +7,7 @@ export class Settings {
   triggerOnWindowCreated = false;
 
   static load() {
-    return chrome.storage.sync.get({settings: ''})
+    return chrome.storage.sync.get({settings: '{}'})
       .then(item => item.settings)
       .then(settings => (settings ?
                          Object.assign(new Settings(), JSON.parse(settings))

--- a/window_manager/options.html
+++ b/window_manager/options.html
@@ -16,37 +16,73 @@
       pre {
         font-size: 9pt;
       }
-      
+
       textarea {
         width: 100%;
       }
+
+      table, th, td {
+        border: 1px solid black;
+        padding: 5px;
+        text-align: center;
+      }
+      th {
+        font-weight: bold;
+        background-color: lightsteelblue;
+      }
+      table {
+        border-collapse: collapse;
+      }
+
     </style>
   </head>
   <body>
     <div id="content">
       <h1>Displays</h1>
-      
-      <ul id="displays"></ul>
+      <table>
+        <thead >
+          <th>Name</th>
+          <th>ID</th>
+          <th>primary</th>
+          <th>internal</th>
+          <th>Desktop position</td>
+        </thead>
+        <tbody id="displays">
+        </tbody>
+      </table>
+
+      <!-- template for a displayRow -->
+      <table style="display: none">
+        <tbody>
+          <tr id="displayRow">
+            <td style="font-weight: bold;">Name</td>
+            <td>ID</td>
+            <td>primary</td>
+            <td>internal</td>
+            <td style="font-family: monospace;">position</td>
+          </tr>
+        </tbody>
+      </table>
 
       <h1>Options</h1>
 
       Please follow the
-      <a href='https://github.com/birnenlabs/chrome-extensions/blob/main/window_manager/README.md'>documentation on github</a>.
-      
+      <a href='https://github.com/birnenlabs/chrome-extensions/blob/main/window_manager/README.md' target="_blank">documentation on github</a>.
+
       <h2>Actions</h2>
-      
+
       <div class="status" id="actionsInputStatus"></div>
       <textarea id="actionsInput" rows="25" cols="50"></textarea>
-      
+
       <h2>Matchers</h2>
-      
+
       <div class="status" id="matchersInputStatus"></div>
       <textarea id="matchersInput" rows="25" cols="50"></textarea>
 
       <h2>Settings</h2>
       <div class="status" id="settingsInputStatus"></div>
       <textarea id="settingsInput" rows="10" cols="50"></textarea>
-  
+
       <div class="status" id="status"></div>
       <button id="validate">Validate</button>
       <button id="format">Format</button>

--- a/window_manager/options.js
+++ b/window_manager/options.js
@@ -1,28 +1,28 @@
-function saveOptions() {
+async function saveOptions() {
   const actions = document.getElementById('actionsInput').value;
   const matchers = document.getElementById('matchersInput').value;
   const settings = document.getElementById('settingsInput').value;
 
-  if (validateOptions()) {
+  if (await validateOptions()) {
     chrome.storage.sync.set(
       {actions, matchers, settings},
       () => {
         setStatus('Options saved');
       }
     );
-  } else {
-    setStatus('Invalid json');
   }
 }
 
-function validateOptions() {
+async function validateOptions() {
   const actions = document.getElementById('actionsInput').value;
   const matchers = document.getElementById('matchersInput').value;
   const settings = document.getElementById('settingsInput').value;
 
   let valid = true;
+  let actionsObj;
+  let matchersObj;
   try {
-    JSON.parse(actions);
+    actionsObj = JSON.parse(actions);
     document.getElementById('actionsInputStatus').textContent = '';
   } catch (e) {
     document.getElementById('actionsInputStatus').textContent = e.message;
@@ -30,7 +30,7 @@ function validateOptions() {
   }
 
   try {
-    JSON.parse(matchers);
+    matchersObj=JSON.parse(matchers);
     document.getElementById('matchersInputStatus').textContent = '';
   } catch (e) {
     document.getElementById('matchersInputStatus').textContent = e.message;
@@ -45,12 +45,83 @@ function validateOptions() {
     valid = false;
   }
 
-  if (valid) {
-    setStatus('Valid');
+  // JSON validation completed
+  //
+  if (! valid) {
+    setStatus('Invalid JSON');
+    return valid;
   }
 
+  const hasWarnings = ! await warnForIncorrectMonitorIds(actionsObj);
+
+  // verify matchers reference valid actions.
+  valid = validateMatchersAndActions(actionsObj, matchersObj);
+
+  if(valid) {
+    if (hasWarnings) {
+      setStatus('Valid with warnings - see above.');
+    } else {
+      setStatus('Configuration validated.');
+    }
+  } else {
+    setStatus('Incorrect configuration - see above.');
+  }
   return valid;
 }
+
+/**
+ * Verify that all Matchers reference a valid Action
+ * @param {*} actionsObj
+ * @param {*} matchersObj
+ * @returns {boolean} if validated successfully
+ */
+function validateMatchersAndActions(actionsObj, matchersObj) {
+  const actionIDs = new Set(actionsObj.map((a) => a.id));
+  const referencedActionIDs = new Set(matchersObj.map((m)=> m.actions).flat());
+
+  const missingActionIds = [...referencedActionIDs.values()].filter((id) => !actionIDs.has(id));
+  if(missingActionIds.length > 0) {
+    document.getElementById('matchersInputStatus').textContent = `Matchers refer to unknown Action ids: ${JSON.stringify(missingActionIds,null,2)}`;
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Check that referenced displays are actually present, and warn if not
+ *
+ * @param {*} actionsObj
+ * @returns {boolean} if no warnings occurred.
+ */
+async function warnForIncorrectMonitorIds(actionsObj){
+  const displays = await chrome.system.display.getInfo({});
+
+  const displayNames = new Set(
+    [
+      ...displays.map((d) => d.name),
+      ...displays.map((d) => d.id.toString()),
+    ]);
+  displayNames.add('primary');
+  if ( displays.filter((d) => d.isPrimary===false).length>0) {
+    displayNames.add('-primary')
+  };
+  if ( displays.filter((d) => d.isInternal).length>0) {
+    displayNames.add('internal')
+  };
+  if ( displays.filter((d) => d.isInternal===false).length>0) {
+    displayNames.add('-internal')
+  };
+
+  const actionDisplayNames = new Set(actionsObj.map((a) => a.display));
+
+  const missingDisplayNames = [...actionDisplayNames.values()].filter((d) => !displayNames.has(d));
+  if(missingDisplayNames.length>0){
+    document.getElementById('actionsInputStatus').textContent = `Warning: Actions refer to the following unknown display names (This is normal if they are not currently connected): ${JSON.stringify(missingDisplayNames,null,2)}`;
+    return false;
+  }
+  return true;
+}
+
 
 function formatOptions() {
   const actions = document.getElementById('actionsInput').value;
@@ -73,18 +144,33 @@ function restoreOptions() {
       document.getElementById('actionsInput').value = items.actions;
       document.getElementById('matchersInput').value = items.matchers;
       document.getElementById('settingsInput').value = items.settings;
+      validateOptions();
     }
   );
 }
 
 async function showDisplays() {
   const displays = await chrome.system.display.getInfo({});
-  const el = document.getElementById('displays');
-  el.textContent = '';
+
+  // Sort displays by position on desktop -> left to right, then top to bottom
+  displays.sort((d1,d2) => d1.bounds.top - d2.bounds.top);
+  displays.sort((d1,d2) => d1.bounds.left - d2.bounds.left);
+
+  const displayTable = document.getElementById('displays');
+  const displayRowTemplate = document.getElementById('displayRow');
+  displayTable.replaceChildren();
   for (const display of displays) {
-    const displayEl = document.createElement('li');
-    displayEl.textContent = `name: '${display.name}', primary: '${display.isPrimary}', internal: '${display.isInternal}'`;
-    el.appendChild(displayEl);
+    const displayRow = displayRowTemplate.cloneNode(true);
+    const cols = [...displayRow.getElementsByTagName('td')];
+
+    cols[0].replaceChildren(document.createTextNode(display.name));
+    cols[1].replaceChildren(document.createTextNode(display.id));
+    cols[2].replaceChildren(document.createTextNode(display.isPrimary));
+    cols[3].replaceChildren(document.createTextNode(display.isInternal));
+    delete display.bounds.height;
+    delete display.bounds.width;
+    cols[4].replaceChildren(document.createTextNode(JSON.stringify(display.bounds,null,2)));
+    displayTable.appendChild(displayRow);
   }
 }
 
@@ -93,7 +179,7 @@ function setStatus(text) {
   status.textContent = text;
   setTimeout(() => {
     status.textContent = '';
-  }, 2000);
+  }, 5000);
 }
 
 document.addEventListener('DOMContentLoaded', restoreOptions);
@@ -101,4 +187,18 @@ document.addEventListener('DOMContentLoaded', showDisplays);
 document.getElementById('save').addEventListener('click', saveOptions);
 document.getElementById('validate').addEventListener('click', validateOptions);
 document.getElementById('format').addEventListener('click', formatOptions);
+
+chrome.system.display.onDisplayChanged.addListener(showDisplays);
+
+document.addEventListener('keydown',
+    function (event) {
+        if (event.key === 's' && !event.shiftKey && !event.altKey &&
+          // ctrl or mac-command=meta-key
+          ( (event.ctrlKey && !event.metaKey)
+            || (!event.ctrlKey && event.metaKey))) {
+            // Ctrl-S or CMD-S pressed
+            saveOptions();
+            event.preventDefault();
+        }
+    });
 

--- a/window_manager/options.js
+++ b/window_manager/options.js
@@ -30,7 +30,7 @@ async function validateOptions() {
   }
 
   try {
-    matchersObj=JSON.parse(matchers);
+    matchersObj = JSON.parse(matchers);
     document.getElementById('matchersInputStatus').textContent = '';
   } catch (e) {
     document.getElementById('matchersInputStatus').textContent = e.message;
@@ -47,7 +47,7 @@ async function validateOptions() {
 
   // JSON validation completed
   //
-  if (! valid) {
+  if (!valid) {
     setStatus('Invalid JSON');
     return valid;
   }

--- a/window_manager/worker.js
+++ b/window_manager/worker.js
@@ -50,6 +50,7 @@ async function updateWindowsFromArray(windows) {
   }
   // Filter out matchers with no (remaining) valid actions
   matchers = matchers.filter((m) => m.actions.length > 0);
+  console.log('Got valid matchers for current displays: ',matchers);
 
   // orderArray[i] will contain all window ids matched by matcher number i
   const orderArray = matchers.map(() => []);
@@ -61,13 +62,14 @@ async function updateWindowsFromArray(windows) {
     const windowUpdate = {};
     for (let i = 0; i < matchers.length; i++) {
       if (matchers[i].matches(window)) {
-        // we have already filtered out invalid/irrelevant actions from the matcher, so take the last action in the list.
-        const actionName = matchers[i].actions.at(-1);
-        console.log(`Matched ${actionName} to window:`, window.tabs[0]?.url, window.tabs);
+        for (const actionName of matchers[i].actions) {
+          // we only have valid actions in the action list.
+          console.log(`Matched ${actionName} to window:`, (window.tabs[0]?.url || window.tabs[0]?.pendingUrl), window.tabs);
 
-        orderArray[i].push(window.id);
-        // merge window updates from tbis action with existing window updates.
-        Object.assign(windowUpdate,actions.get(actionName));
+          orderArray[i].push(window.id);
+          // merge window updates from tbis action with existing window updates.
+          Object.assign(windowUpdate,actions.get(actionName));
+        }
       }
     }
 

--- a/window_manager/worker.js
+++ b/window_manager/worker.js
@@ -1,6 +1,5 @@
 import {Action} from './classes/action.js';
 import {Matcher} from './classes/matcher.js'
-import {Position} from './classes/position.js';
 
 const UPDATE_TIMEOUT_MS = 5;
 
@@ -9,8 +8,13 @@ export async function updateWindowWithActions(actions) {
   const windowPromise = chrome.windows.getLastFocused();
   const displayPromise = chrome.system.display.getInfo({});
 
+  const windowUpdate = {};
+  // merge actions - createUpdate only returns values for actions with valid displays.
   for (const action of actions) {
-    chrome.windows.update((await windowPromise).id, action.createUpdate(await displayPromise));
+    Object.assign(windowUpdate,action.createUpdate(await displayPromise));
+  }
+  if(Object.keys(windowUpdate).length > 0 ) {
+    chrome.windows.update((await windowPromise).id, windowUpdate);
   }
 }
 
@@ -29,19 +33,24 @@ async function updateWindowsFromArray(windows) {
   const matchersPromise = Matcher.loadAll();
 
   const displays = await displaysPromise;
-  const actions = new Map((await actionsPromise)
-                          .map(a => [a.id, a.createUpdate(displays)]));
-  const matchers = await matchersPromise;
 
+  // create a map of action name -> windowUpdate object for only actions valid for the current set of displays:
+  const actions = new Map(
+    (await actionsPromise)
+      .map(a => [a.id, a.createUpdate(displays)])
+      // createUpdate returns null when no matching display.
+      .filter((pair) => pair[1] != null ));
+  console.log('Got valid actions for current displays: ',[...actions.keys()]);
+
+  let matchers = await matchersPromise;
+
+  // Filter out invalid/unknown actions from each matcher
   for (const matcher of matchers) {
-    for (const action of matcher.actions) {
-      if (!actions.has(action)) {
-        throw new Error(`Action: ${action} not defined.`); 
-      }
-    }
+    matcher.actions = matcher.actions.filter((a) => actions.has(a));
   }
+  // Filter out matchers with no (remaining) valid actions
+  matchers = matchers.filter((m) => m.actions.length > 0);
 
-  console.debug(actions);
   // orderArray[i] will contain all window ids matched by matcher number i
   const orderArray = matchers.map(() => []);
   // actionMap will contain action (windowUpdate object) and use window id as key.
@@ -49,29 +58,23 @@ async function updateWindowsFromArray(windows) {
 
   var timeout = 0;
   for (const window of windows) {
-    console.log('Matching', window.tabs[0]?.url, window.tabs);
     const windowUpdate = {};
-  
     for (let i = 0; i < matchers.length; i++) {
       if (matchers[i].matches(window)) {
-        for (const action of matchers[i].actions) {
-          const actionWindowUpdate = actions.get(action);
-          if (Object.entries(actionWindowUpdate).length > 0) {
-            orderArray[i].push(window.id);
-            for (const [key, value] of Object.entries(actionWindowUpdate)) {
-              windowUpdate[key] = value;
-            }
-          }
-        }
+        // we have already filtered out invalid/irrelevant actions from the matcher, so take the last action in the list.
+        const actionName = matchers[i].actions.at(-1);
+        console.log(`Matched ${actionName} to window:`, window.tabs[0]?.url, window.tabs);
+
+        orderArray[i].push(window.id);
+        // merge window updates from tbis action with existing window updates.
+        Object.assign(windowUpdate,actions.get(actionName));
       }
     }
 
-    // all windows to update are set to be focused so we can check for the existence of this flag.
-    if (windowUpdate.focused) {
-      console.log('Will update', window.tabs[0]?.url, windowUpdate);
+    // If something to apply, apply it!
+    if (Object.keys(windowUpdate).length > 0 ) {
+      console.log('Will update window with', windowUpdate);
       windowUpdateMap.set(window.id, windowUpdate);
-    } else {
-      console.log('No match');
     }
   }
 


### PR DESCRIPTION
Displays can also be specified by ID in Actions

Options page:
Show displays in a table in Options, with ID and position Add validation of matchers' action IDs in Options
Add validation of actions' display Name
Add CTRL-S shortcut key

Popup only shows shortcut buttons for active displays

Make matching a bit cleaner/safer - filter by valid actions for current displays - removes possibility of runtime errors.
Improve logging for matching.