### PR TITLE
Add support for specifying the index of the matched display

### DIFF
--- a/window_manager/README.md
+++ b/window_manager/README.md
@@ -10,17 +10,30 @@ Action defines how the window should be moved and resized. Following fields are 
 
 - `id` - **required**, identifier of the action, used in matchers to reference the action
 
-- `display` - **required**, name of display, the action will not be performed if the display of given name doesn't exist.
+- `display` - **required**, name of display, the action will not be performed
+if there is no active display matching this name.
 
   Available values:
-  - `primary` - display defined as primary
-  - `-primary` - display that is not primary (if there are multiple non primary displays the first one will be used)
-  - `internal` - display defined as internal
-  - `-internal` - display that is not internal (if there are multiple non internal displays the first one will be used)
+  - `primary` - display defined as primary.
+  - `-primary` - display that is not primary.
+  - `internal` - display defined as internal.
+  - `-internal` - display that is not internal.
   - `[name of the display]` - name of the display, e.g. `DELL U4021QW`.
-  - `[id of the display]` - ChromeOS internal display ID (useful when you have multiple displays with the same name)
+  - `[id of the display]` - ChromeOS internal display ID, e.g. `73492720573986543`.
 
-  _Hint: A List of displays with their names and IDs is printed at the top of the extension options page._
+  If you have multiple displays that match the display name, you can specify the
+  index of the display to used as follows:
+
+  - `-internal[0]` - the first non-internal display
+  - `-internal[1]` - the second non-internal display
+  - `HP Z27n[1]` - the second "HP Z27n" display
+
+  Displays are ordered by their desktop arrangement:
+  from left to right, then from top to bottom. If no index is specified,
+  the first matched (ie leftmost) will be used.
+
+  _Hint: A List of displays with their names, IDs and desktop position in this
+  sort order is shown at the top of the extension options page._
 
 - `shortcutId` - action will be triggered by the shortcut of given id as defined on the shortcuts page (`chrome://extensions/shortcuts`).
 
@@ -128,6 +141,7 @@ Since the extension requires JSON knowledge to define the actions and matchers, 
 - `popupBackgroundColor` - string definition of color of the popup window background that is opened by the left click on the extension (e.g. `"white"`).
 - `popupButtonColor` - string definition of color of the popup window buttons (e.g. `"#f9f9f9"`).
 - `triggerOnMonitorChange` - boolean value - when true, the extension will rearrange all the windows when new monitors are connected or disconnected
+- `triggerOnMonitorChangeTimeout` - number - wait for this many milliseconds before rearranging windows when monitors change (default 1000).
 - `triggerOnWindowCreated` - boolean value - when true, the extension will apply matchers to newly created windows
 
 

--- a/window_manager/classes/action.js
+++ b/window_manager/classes/action.js
@@ -43,7 +43,7 @@ export class Action {
    * @return {?chrome.system.display.DisplayUnitInfo}
    */
   findDisplay(displays) {
-    return Action.findDisplaybyName(this.display, displays);
+    return Action.findDisplayByName(this.display, displays);
   }
 
   /**
@@ -53,7 +53,7 @@ export class Action {
    * @param {chrome.system.display.DisplayUnitInfo[]} displays
    * @return {?chrome.system.display.DisplayUnitInfo}
    */
-  static findDisplaybyName(displayName, displays) {
+  static findDisplayByName(displayName, displays) {
     let prefixDisplayName=displayName;
     let displayIndex = 0;
     // look for a [N] suffix, and split display name into prefix and suffix

--- a/window_manager/options.html
+++ b/window_manager/options.html
@@ -45,7 +45,7 @@
           <th>ID</th>
           <th>primary</th>
           <th>internal</th>
-          <th>Desktop position</td>
+          <th>Desktop arrangement</td>
         </thead>
         <tbody id="displays">
         </tbody>
@@ -89,6 +89,7 @@
       <button id="save">Save</button>
     </div>
 
-    <script src="./options.js"></script>
+    <script src="./options.js"
+            type="module"></script>
   </body>
 </html>

--- a/window_manager/options.js
+++ b/window_manager/options.js
@@ -100,7 +100,7 @@ async function warnForIncorrectMonitorIds(actionsObj) {
   const actionDisplayNames = new Set(actionsObj.map((a) => a.display));
 
   const missingDisplayNames = [...actionDisplayNames.values()]
-      .filter((d) => Action.findDisplaybyName(d, displays)===null);
+      .filter((d) => Action.findDisplayByName(d, displays)===null);
 
   if (missingDisplayNames.length>0) {
     document.getElementById('actionsInputStatus').textContent =

--- a/window_manager/options.js
+++ b/window_manager/options.js
@@ -1,3 +1,5 @@
+import {Action} from './classes/action.js';
+
 async function saveOptions() {
   const actions = document.getElementById('actionsInput').value;
   const matchers = document.getElementById('matchersInput').value;
@@ -95,28 +97,14 @@ function validateMatchersAndActions(actionsObj, matchersObj) {
  */
 async function warnForIncorrectMonitorIds(actionsObj) {
   const displays = await chrome.system.display.getInfo({});
-
-  const displayNames = new Set(
-      [
-        ...displays.map((d) => d.name),
-        ...displays.map((d) => d.id.toString()),
-      ]);
-  displayNames.add('primary');
-  if ( displays.filter((d) => d.isPrimary===false).length>0) {
-    displayNames.add('-primary');
-  };
-  if ( displays.filter((d) => d.isInternal).length>0) {
-    displayNames.add('internal');
-  };
-  if ( displays.filter((d) => d.isInternal===false).length>0) {
-    displayNames.add('-internal');
-  };
-
   const actionDisplayNames = new Set(actionsObj.map((a) => a.display));
 
-  const missingDisplayNames = [...actionDisplayNames.values()].filter((d) => !displayNames.has(d));
+  const missingDisplayNames = [...actionDisplayNames.values()]
+      .filter((d) => Action.findDisplaybyName(d, displays)===null);
+
   if (missingDisplayNames.length>0) {
-    document.getElementById('actionsInputStatus').textContent = `Warning: Actions refer to the following unknown display names (This is normal if they are not currently connected): ${JSON.stringify(missingDisplayNames, null, 2)}`;
+    document.getElementById('actionsInputStatus').textContent =
+        `Warning: Actions refer to the following unknown display names (This is normal if they are not currently connected): ${JSON.stringify(missingDisplayNames, null, 2)}`;
     return false;
   }
   return true;


### PR DESCRIPTION
Allow specifying the 'nth' matching display using an array index suffix, for example: 

* `"-internal[1]"`
* `"HP Z27n[0]"`