### PR TITLE
Do not read from synced storage all the time - keep a copy in Session storage

### DIFF
--- a/window_manager/background.js
+++ b/window_manager/background.js
@@ -85,3 +85,10 @@ chrome.runtime.onMessage.addListener(
       return promise.catch((e) => console.error(`onMessage failed with error: ${e.message}.`));
     },
 );
+
+
+// If synced storage changes, refresh local copy.
+chrome.storage.sync.onChanged.addListener((changes) => {
+  console.info(`${new Date().toLocaleTimeString()} synced config updated: changed keys: ${Object.keys(changes)}`);
+  storage.refreshConfigFromSyncedStorage();
+});

--- a/window_manager/classes/storage.js
+++ b/window_manager/classes/storage.js
@@ -98,7 +98,7 @@ export class Storage {
         }`));
   }
 
-  /** refreshes local and sessiion storage from synced storage */
+  /** refreshes local and session storage from synced storage */
   refreshConfigFromSyncedStorage() {
     this.validatedConfiguration = Storage.loadConfigFromSyncedStorage();
   }

--- a/window_manager/classes/storage.js
+++ b/window_manager/classes/storage.js
@@ -119,18 +119,18 @@ export class Storage {
   }
 
   /** @return {Promise<Action[]>} */
-  async getActions() {
-    return (await this.validatedConfiguration).actions;
+  getActions() {
+    return this.validatedConfiguration.then((config) => config.actions);
   }
 
   /** @return {Promise<Matcher[]>} */
-  async getMatchers() {
-    return (await this.validatedConfiguration).matchers;
+  getMatchers() {
+    return this.validatedConfiguration.then((config) => config.matchers);
   }
 
   /** @return {Promise<Settings>} */
-  async getSettings() {
-    return (await this.validatedConfiguration).settings;
+  getSettings() {
+    return this.validatedConfiguration.then((config) => config.settings);
   }
 
   /**

--- a/window_manager/options.js
+++ b/window_manager/options.js
@@ -11,8 +11,6 @@ import * as schemaValidator from './jsoneditor/schema-validator.js';
  * @typedef {import('./classes/storage.js').ValidatedConfiguration} ValidatedConfiguration
  */
 
-const storage = new Storage();
-
 /**
  * @param {string} field
  * @param {string} message
@@ -39,7 +37,7 @@ function validateJson() {
     matchers: getJsonTextFromEditor(matchersEditor),
     settings: getJsonTextFromEditor(settingsEditor),
   };
-  const validatedConfig = storage.parse(config);
+  const validatedConfig = Storage.parse(config);
 
   // Also check editors validation.
   if (actionsEditor.validate() != null || matchersEditor.validate() != null || settingsEditor.validate() != null) {
@@ -403,7 +401,7 @@ function onPageLoad() {
   matchersEditor = createJSONEditorForElement('matchersInput', [], schemaValidator.matchers);
   settingsEditor = createJSONEditorForElement('settingsInput', {}, schemaValidator.settings);
 
-  return storage.getRawConfiguration().then((config) => {
+  return Storage.getRawConfiguration().then((config) => {
     actionsEditor.set({text: config.actions});
     matchersEditor.set({text: config.matchers});
     settingsEditor.set({text: config.settings});
@@ -429,7 +427,7 @@ function onDisplayChanged() {
 /** @return {Promise<void>} */
 function onSaveClick() {
   return validateEverything()
-      .then((validatedConfig) => storage.save(validatedConfig))
+      .then((validatedConfig) => Storage.save(validatedConfig))
       .then(() => setStatus('Options saved'))
       .then(() => undefined)
       .catch((e) => setStatus(e.message));


### PR DESCRIPTION
Keeps a copy of the config in Session storage, as well as in Session object local memory. 

service worker has an onChanged event handler  which copies synced storage to session storage.

This is much faster at reading storage when the service worker is stopped and restarted - reading from synced storage can sometimes take seconds, while reading from session storage is near-instant. 

Makes options page and popup quicker to open, and service worker faster to respond as no synced storage load, parsing and validation is needed.

Also remove construction of the Storage object from options as it is not needed (it only needs getRawConfiguration(). parse() and save() and maybeFormat() which are made static).