### PR TITLE
Add a build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ window_manager/jsoneditor/*.ts
 .history/
 
 package-lock.json
-
+target/

--- a/build-extension.sh
+++ b/build-extension.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+package_dir="$(dirname $0)"
+
+case "$1" in
+  ( "" | .* | */* )
+    echo 'usage: build-extension.sh EXTENSION_SUBDIR'
+    exit 1;;
+esac
+
+if [[ ! -d "$package_dir/$1" ]]
+then
+    echo "subdirectory: $1 does not exist"
+    exit 1
+fi
+
+zipfile="${package_dir}/target/$1.zip"
+
+echo "Building $zipfile..."
+
+set -e # exit on error
+
+mkdir -p "$package_dir/target"
+cd "$package_dir/$1"
+npm install
+npm run eslint
+npm run typecheck
+npm run generate-files
+zip -rv "$zipfile" .
+echo ""
+echo "Built $zipfile"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "eslint": "npx eslint '**/*.*js' --ignore-pattern '**/jsoneditor/*'",
     "eslint-fix": "npx eslint --fix '**/*.*js'  --ignore-pattern '**/jsoneditor/*'",
     "typecheck": "tsc --project jsconfig.json --maxNodeModuleJsDepth 0 --noEmit",
-    "build-wm-files": "cp node_modules/vanilla-jsoneditor/standalone.* window_manager/jsoneditor/ && cd window_manager && node ./generate-schema-validator.mjs"
+    "generate-files": "cp node_modules/vanilla-jsoneditor/standalone.* window_manager/jsoneditor/ && cd window_manager && node ./generate-schema-validator.mjs",
+    "build-wm-files": "npm run generate-files",
+    "build-extension": "$(dirname $npm_package_json)/build-extension.sh"
   }
 }


### PR DESCRIPTION
Adds a `build-extension.sh` script that performs all checks, tasks and builds a zipfile for the given extension subdirectory name. 

eg: 
```sh
# from chrome-extensions directory
./build-extension.sh window_manager
```

or

```sh
# from anywhere in the chrome-extensions tree
npm run build-extension window_manager
```